### PR TITLE
change PDO Error-Mode for PHP 8

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -29,7 +29,7 @@ function open_db()
         $db = false;
         $_SESSION['error_message'] = "Database error {$e->getCode()}: {$e->getMessage()}";
     }
-
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
     return $db;
 }
 


### PR DESCRIPTION
Starting with PHP 8.0.0 the PDO Error-Mode is set to PDO::ERRMODE_EXCEPTION as default (Prior it was PDO::ERRMODE_SILENT). This leads to an uncaught PDOexception in db.php function tableExists after clean install with an empty database. Of cause the resulting admin-page is empty with a 500 Internal server fault.

I fixed this for me by changing the error-mode to the old default value after connect.